### PR TITLE
Alpha version Activity transition

### DIFF
--- a/library/src/main/java/com/transitionseverywhere/ActivityTransitionManager.java
+++ b/library/src/main/java/com/transitionseverywhere/ActivityTransitionManager.java
@@ -1,0 +1,131 @@
+package com.transitionseverywhere;
+
+import android.annotation.TargetApi;
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Handler;
+import android.util.TypedValue;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.transitionseverywhere.activity.ActivityTransitionOptions;
+import com.transitionseverywhere.activity.TransitionData;
+
+import java.util.ArrayList;
+
+public class ActivityTransitionManager extends TransitionManager {
+    private static final String LOG_TAG = "ActivityTransitionManager";
+    private static Transition transition;
+    private static ArrayList<TransitionData> transitionData;
+
+    public static void startActivity(Activity activity, Class<?> cls) {
+        ViewGroup content = (ViewGroup) activity.findViewById(android.R.id.content);
+        startActivity(activity, cls, content);
+    }
+
+    public static void startActivity(Activity activity, Class<?> cls, View content) {
+        Intent intent = new Intent(activity, cls);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+            Bundle transitionBundle = ActivityTransitionOptions.fromView(content);
+            intent.putExtras(transitionBundle);
+        }
+        activity.startActivity(intent);
+        activity.overridePendingTransition(0, 0);
+    }
+
+    public static void setContentView(Activity activity, int layoutId, Bundle bundle) {
+        setContentView(activity, layoutId, bundle, sDefaultTransition);
+    }
+
+    public static void setContentView(Activity activity, int layoutId, Bundle bundle,
+                                      Transition transition) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+            ActivityTransitionManager.transition = transition;
+            startTransition(activity, layoutId, bundle, transition);
+        } else {
+            activity.setContentView(layoutId);
+        }
+    }
+
+    public static void onGoBack(Activity activity) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+            exitTransition(activity);
+        } else {
+            activity.finish();
+        }
+    }
+
+    private static void startTransition(Activity activity, int layoutId, Bundle bundle,
+                                        Transition transition) {
+        ViewGroup decorView = (ViewGroup) activity.findViewById(android.R.id.content);
+        FrameLayout phantomView = new FrameLayout(activity.getApplicationContext());
+        phantomView.setId(R.id.phantom_view);
+        ActivityTransitionManager.transitionData = ActivityTransitionOptions.fromTransitionBundle(bundle);
+        for (TransitionData data : transitionData) {
+            View view = new View(activity.getApplicationContext());
+            setParamsForView(view, phantomView, data);
+        }
+        activity.setContentView(phantomView);
+        Scene newScene = Scene.getSceneForLayout(decorView, layoutId, activity);
+        changeScene(newScene, transition);
+    }
+
+    private static void exitTransition(final Activity activity) {
+        ViewGroup content = (ViewGroup) activity.findViewById(android.R.id.content);
+        FrameLayout phantomView = new FrameLayout(activity.getApplicationContext());
+        for (TransitionData data : transitionData) {
+            View view = activity.findViewById(data.getId());
+            if (view != null) {
+                if (view instanceof ImageView) {
+                    ImageView imageView = new ImageView(activity);
+                    imageView.setImageDrawable(((ImageView) view).getDrawable());
+                    setParamsForView(imageView, phantomView, data);
+                } else if (view instanceof TextView) {
+                    TextView textView = new TextView(activity);
+                    textView.setText(((TextView) view).getText());
+                    textView.setTextColor(((TextView) view).getTextColors());
+                    textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, ((TextView) view).getTextSize());
+                    setParamsForView(textView, phantomView, data);
+                } else {
+                    View temp = new View(activity);
+                    setParamsForView(temp, phantomView, data);
+                    if (Build.VERSION.SDK_INT >= 16) {
+                        temp.setBackground(view.getBackground());
+                    } else {
+                        temp.setBackgroundDrawable(view.getBackground());
+                    }
+                }
+            }
+        }
+        Scene exitScene = Scene.getSceneForView(content, phantomView);
+        changeScene(exitScene, transition);
+        Handler handler = new Handler();
+        handler.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                activity.finish();
+                activity.overridePendingTransition(0, 0);
+            }
+        }, transition.getDuration());
+    }
+
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
+    private static void setParamsForView(View view, ViewGroup viewGroup, TransitionData data) {
+        view.setId(data.getId());
+        view.setLeft(data.getLeft());
+        view.setTop(data.getTop());
+        view.setRight(data.getLeft() + data.getWidth());
+        view.setBottom(data.getTop() + data.getHeight());
+        viewGroup.addView(view);
+        FrameLayout.LayoutParams layoutParams = (FrameLayout.LayoutParams) view.getLayoutParams();
+        layoutParams.width = data.getWidth();
+        layoutParams.height = data.getHeight();
+        //for debug
+        layoutParams.setMargins(data.getLeft(), data.getTop(), 0, 0);
+    }
+}

--- a/library/src/main/java/com/transitionseverywhere/Scene.java
+++ b/library/src/main/java/com/transitionseverywhere/Scene.java
@@ -67,6 +67,23 @@ public final class Scene {
         }
     }
 
+
+    public static Scene getSceneForView(ViewGroup sceneRoot, View view) {
+        SparseArray<Scene> scenes = (SparseArray<Scene>) sceneRoot.getTag(R.id.scene_layoutid_cache);
+        if (scenes == null) {
+            scenes = new SparseArray<Scene>();
+            sceneRoot.setTag(R.id.scene_layoutid_cache, scenes);
+        }
+        Scene scene = scenes.get(view.getId());
+        if (scene != null) {
+            return scene;
+        } else {
+            scene = new Scene(sceneRoot, view);
+            scenes.put(view.getId(), scene);
+            return scene;
+        }
+    }
+
     /**
      * Constructs a Scene with no information about how values will change
      * when this scene is applied. This constructor might be used when

--- a/library/src/main/java/com/transitionseverywhere/TransitionManager.java
+++ b/library/src/main/java/com/transitionseverywhere/TransitionManager.java
@@ -70,7 +70,7 @@ public class TransitionManager {
 
     private static String LOG_TAG = "TransitionManager";
 
-    private static Transition sDefaultTransition = new AutoTransition();
+    protected static Transition sDefaultTransition = new AutoTransition();
 
     private static final String[] EMPTY_STRINGS = new String[0];
 
@@ -181,7 +181,7 @@ public class TransitionManager {
      * @param scene      The scene being entered
      * @param transition The transition to play for this scene change
      */
-    private static void changeScene(Scene scene, Transition transition) {
+    protected static void changeScene(Scene scene, Transition transition) {
 
         final ViewGroup sceneRoot = scene.getSceneRoot();
         if (!sPendingTransitions.contains(sceneRoot)) {

--- a/library/src/main/java/com/transitionseverywhere/activity/ActivityTransitionOptions.java
+++ b/library/src/main/java/com/transitionseverywhere/activity/ActivityTransitionOptions.java
@@ -1,0 +1,64 @@
+package com.transitionseverywhere.activity;
+
+import android.content.res.Resources;
+import android.os.Bundle;
+import android.view.View;
+import android.view.ViewGroup;
+
+import java.util.ArrayList;
+
+public class ActivityTransitionOptions {
+    public static final String ARRAY_KEY = "ARRAY_KEY";
+
+    public static Bundle fromView(View fromView) {
+        Bundle bundle = new Bundle();
+        bundle.putParcelableArrayList(ARRAY_KEY, getViewsWithId(fromView));
+        return bundle;
+    }
+
+    public static ArrayList<TransitionData> fromTransitionBundle(Bundle bundle) {
+        return bundle.getParcelableArrayList(ARRAY_KEY);
+    }
+
+    public static ArrayList<TransitionData> getViewsWithId(View view) {
+        if (view.getVisibility() != View.VISIBLE) {
+            return null;
+        }
+        ArrayList<TransitionData> viewDatas = new ArrayList<>();
+        int groupTransitionName = view.getId();
+        if (groupTransitionName > 0) {
+            int[] screenLocation = new int[2];
+            view.getLocationOnScreen(screenLocation);
+            int statusBarHeight = getStatusBarHeight(view.getResources());
+            final TransitionData viewData = new TransitionData(view.getId(),
+                    screenLocation[0],
+                    screenLocation[1] - statusBarHeight, view.getWidth(), view.getHeight());
+            viewDatas.add(viewData);
+        }
+        if (view instanceof ViewGroup) {
+            int count = ((ViewGroup) view).getChildCount();
+            if (count > 0) {
+                for (int i = 0; i < count; i++) {
+                    View child = ((ViewGroup) view).getChildAt(i);
+                    ArrayList<TransitionData> childDatas = getViewsWithId(child);
+                    if (childDatas != null) {
+                        for (TransitionData data : childDatas) {
+                            viewDatas.add(data);
+                        }
+                    }
+                }
+
+            }
+        }
+        return viewDatas;
+    }
+
+    private static int getStatusBarHeight(Resources resources) {
+        int result = 0;
+        int resourceId = resources.getIdentifier("status_bar_height", "dimen", "android");
+        if (resourceId > 0) {
+            result = resources.getDimensionPixelSize(resourceId);
+        }
+        return result;
+    }
+}

--- a/library/src/main/java/com/transitionseverywhere/activity/TransitionData.java
+++ b/library/src/main/java/com/transitionseverywhere/activity/TransitionData.java
@@ -1,0 +1,97 @@
+package com.transitionseverywhere.activity;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+public class TransitionData implements Parcelable {
+    private final int id;
+    private final int top;
+    private final int left;
+    private final int width;
+    private final int height;
+
+    public TransitionData(int id, int left, int top, int width, int height) {
+        this.id = id;
+        this.top = top;
+        this.left = left;
+        this.width = width;
+        this.height = height;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public int getTop() {
+        return top;
+    }
+
+    public int getLeft() {
+        return left;
+    }
+
+    public int getWidth() {
+        return width;
+    }
+
+    public int getHeight() {
+        return height;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        TransitionData that = (TransitionData) o;
+
+        if (id != that.id) return false;
+        if (top != that.top) return false;
+        if (left != that.left) return false;
+        if (width != that.width) return false;
+        return height == that.height;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = id;
+        result = 31 * result + top;
+        result = 31 * result + left;
+        result = 31 * result + width;
+        result = 31 * result + height;
+        return result;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeInt(this.id);
+        dest.writeInt(this.top);
+        dest.writeInt(this.left);
+        dest.writeInt(this.width);
+        dest.writeInt(this.height);
+    }
+
+    protected TransitionData(Parcel in) {
+        this.id = in.readInt();
+        this.top = in.readInt();
+        this.left = in.readInt();
+        this.width = in.readInt();
+        this.height = in.readInt();
+    }
+
+    public static final Parcelable.Creator<TransitionData> CREATOR = new Parcelable.Creator<TransitionData>() {
+        public TransitionData createFromParcel(Parcel source) {
+            return new TransitionData(source);
+        }
+
+        public TransitionData[] newArray(int size) {
+            return new TransitionData[size];
+        }
+    };
+}

--- a/library/src/main/res/values/ids.xml
+++ b/library/src/main/res/values/ids.xml
@@ -24,4 +24,5 @@
     <item type="id" name="parentMatrix" />
     <item type="id" name="scene_layoutid_cache"/>
     <item type="id" name="group_layouttransition_cache"/>
+    <item type="id" name="phantom_view"/>
 </resources>

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -15,6 +15,8 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".NewActivity1"/>
+        <activity android:name=".NewActivity2"/>
     </application>
 
 </manifest>

--- a/sample/src/main/java/com/andkulikov/transitionseverywhere/MainActivity.java
+++ b/sample/src/main/java/com/andkulikov/transitionseverywhere/MainActivity.java
@@ -7,6 +7,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.RadioGroup;
 
+import com.transitionseverywhere.ActivityTransitionManager;
 import com.transitionseverywhere.ChangeBounds;
 import com.transitionseverywhere.ChangeImageTransform;
 import com.transitionseverywhere.Scene;
@@ -15,17 +16,21 @@ import com.transitionseverywhere.TransitionInflater;
 import com.transitionseverywhere.TransitionManager;
 import com.transitionseverywhere.TransitionSet;
 
-public class MainActivity extends Activity implements RadioGroup.OnCheckedChangeListener {
+public class MainActivity extends Activity implements RadioGroup.OnCheckedChangeListener, View.OnClickListener {
 
     // We transition between these Scenes
     private Scene mScene1;
     private Scene mScene2;
     private Scene mScene3;
 
-    /** A custom TransitionManager */
+    /**
+     * A custom TransitionManager
+     */
     private TransitionManager mTransitionManagerForScene3;
 
-    /** Transitions take place in this ViewGroup. We retain this for the dynamic transition on scene 4. */
+    /**
+     * Transitions take place in this ViewGroup. We retain this for the dynamic transition on scene 4.
+     */
     private ViewGroup mSceneRoot;
 
     @Override
@@ -45,6 +50,9 @@ public class MainActivity extends Activity implements RadioGroup.OnCheckedChange
 
         // Another scene from a layout resource file.
         mScene3 = Scene.getSceneForLayout(mSceneRoot, R.layout.scene3, this);
+
+        findViewById(R.id.open_new_activity_1).setOnClickListener(this);
+        findViewById(R.id.open_new_activity_2).setOnClickListener(this);
 
         // We create a custom TransitionManager for Scene 3, in which ChangeBounds, Fade and
         // ChangeImageTransform take place at the same time.
@@ -94,4 +102,16 @@ public class MainActivity extends Activity implements RadioGroup.OnCheckedChange
         }
     }
 
+    @Override
+    public void onClick(View v) {
+        switch (v.getId()) {
+            case R.id.open_new_activity_1:
+                ActivityTransitionManager.startActivity(MainActivity.this, NewActivity1.class);
+                break;
+            case R.id.open_new_activity_2:
+                View view = findViewById(R.id.transition_image);
+                ActivityTransitionManager.startActivity(MainActivity.this, NewActivity2.class, view);
+                break;
+        }
+    }
 }

--- a/sample/src/main/java/com/andkulikov/transitionseverywhere/NewActivity1.java
+++ b/sample/src/main/java/com/andkulikov/transitionseverywhere/NewActivity1.java
@@ -1,0 +1,37 @@
+package com.andkulikov.transitionseverywhere;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.view.Gravity;
+
+import com.transitionseverywhere.ActivityTransitionManager;
+import com.transitionseverywhere.ChangeBounds;
+import com.transitionseverywhere.ChangeImageTransform;
+import com.transitionseverywhere.Slide;
+import com.transitionseverywhere.TransitionSet;
+
+
+public class NewActivity1 extends Activity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        Bundle params = getIntent().getExtras();
+        if (params != null) {
+            TransitionSet set = new TransitionSet();
+            Slide slide = new Slide(Gravity.LEFT);
+            slide.addTarget(R.id.transition_title);
+            set.addTransition(slide);
+            set.addTransition(new ChangeBounds());
+            set.addTransition(new ChangeImageTransform());
+            set.setOrdering(TransitionSet.ORDERING_TOGETHER);
+            set.setDuration(350);
+            ActivityTransitionManager.setContentView(this, R.layout.new_activity_1, params, set);
+        }
+    }
+
+    @Override
+    public void onBackPressed() {
+        ActivityTransitionManager.onGoBack(this);
+    }
+}

--- a/sample/src/main/java/com/andkulikov/transitionseverywhere/NewActivity2.java
+++ b/sample/src/main/java/com/andkulikov/transitionseverywhere/NewActivity2.java
@@ -1,0 +1,32 @@
+package com.andkulikov.transitionseverywhere;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.view.Gravity;
+
+import com.transitionseverywhere.ActivityTransitionManager;
+import com.transitionseverywhere.ChangeBounds;
+import com.transitionseverywhere.ChangeImageTransform;
+import com.transitionseverywhere.Slide;
+import com.transitionseverywhere.TransitionSet;
+
+
+public class NewActivity2 extends Activity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        Bundle params = getIntent().getExtras();
+        if (params != null) {
+            TransitionSet set = new TransitionSet();
+            set.addTransition(new ChangeBounds());
+            set.setDuration(350);
+            ActivityTransitionManager.setContentView(this, R.layout.new_activity_2, params, set);
+        }
+    }
+
+    @Override
+    public void onBackPressed() {
+        ActivityTransitionManager.onGoBack(this);
+    }
+}

--- a/sample/src/main/res/layout/activity_basic_transitions.xml
+++ b/sample/src/main/res/layout/activity_basic_transitions.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              android:orientation="vertical"
-              android:paddingBottom="@dimen/activity_vertical_margin"
-              android:paddingLeft="@dimen/activity_horizontal_margin"
-              android:paddingRight="@dimen/activity_horizontal_margin"
-              android:paddingTop="@dimen/activity_vertical_margin">
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin">
 
     <RadioGroup
         android:id="@+id/select_scene"
@@ -19,7 +19,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:text="@string/scene"/>
+            android:text="@string/scene" />
 
         <RadioButton
             android:id="@+id/select_scene_1"
@@ -27,30 +27,48 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:checked="true"
-            android:text="@string/scene_1"/>
+            android:text="@string/scene_1" />
 
         <RadioButton
             android:id="@+id/select_scene_2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:text="@string/scene_2"/>
+            android:text="@string/scene_2" />
 
         <RadioButton
             android:id="@+id/select_scene_3"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:text="@string/scene_3"/>
+            android:text="@string/scene_3" />
 
         <RadioButton
             android:id="@+id/select_scene_4"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:text="@string/scene_4"/>
+            android:text="@string/scene_4" />
 
     </RadioGroup>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/open_new_activity_1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/title_activity_new_1" />
+
+        <Button
+            android:id="@+id/open_new_activity_2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/title_activity_new_2" />
+    </LinearLayout>
 
     <FrameLayout
         android:id="@+id/scene_root"
@@ -58,7 +76,7 @@
         android:layout_height="0dp"
         android:layout_weight="1">
 
-        <include layout="@layout/scene1"/>
+        <include layout="@layout/scene1" />
 
     </FrameLayout>
 

--- a/sample/src/main/res/layout/new_activity_1.xml
+++ b/sample/src/main/res/layout/new_activity_1.xml
@@ -1,0 +1,40 @@
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin">
+
+    <View
+        android:id="@+id/transition_square"
+        android:layout_width="@dimen/square_size_normal"
+        android:layout_height="@dimen/square_size_normal"
+        android:background="#990000"
+        android:layout_gravity="top|left"/>
+
+    <ImageView
+        android:id="@+id/transition_image"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/transition_square"
+        android:src="@drawable/ic_launcher"
+        android:layout_gravity="top|right"/>
+
+    <View
+        android:id="@+id/transition_oval"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:layout_below="@id/transition_image"
+        android:background="@drawable/oval"
+        android:layout_gravity="bottom|left"/>
+
+
+    <TextView
+        android:id="@+id/transition_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/additional_message"
+        android:layout_gravity="center"
+        android:textAppearance="?android:attr/textAppearanceLarge"/>
+</FrameLayout>

--- a/sample/src/main/res/layout/new_activity_2.xml
+++ b/sample/src/main/res/layout/new_activity_2.xml
@@ -1,0 +1,17 @@
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin">
+
+    <ImageView
+        android:id="@+id/transition_image"
+        android:layout_width="200dp"
+        android:layout_height="200dp"
+        android:layout_below="@id/transition_square"
+        android:src="@drawable/ic_launcher"
+        android:layout_gravity="center"/>
+
+</FrameLayout>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -7,6 +7,8 @@
     <string name="scene_2">2</string>
     <string name="scene_3">3</string>
     <string name="scene_4">4</string>
+    <string name="title_activity_new_1">New Activity 1</string>
+    <string name="title_activity_new_2">New Activity 2</string>
     <string name="additional_message">This text fades in.</string>
 
 </resources>


### PR DESCRIPTION
Доброго времени суток. Я попробовал сделать реализацию Transition между Activity на основе вашей библиотеки. Это в принципе более-менее рабочая версия. Просто хотелось бы услышать ваше мнение о такой реализации. 
Суть в том, что мы указываем view содержащий элементы которые нужно анимировать (если не указать берется content). У этой view мы получаем все элементы имеющие id, берем у них параметры нужные для анимации и засовываем все это в Intent. Запускаем новое Activity. На новом Activity на основе пришедших данных формируется FrameLayout. В setContentView мы вставляем этот FrameLayout, создаем сцену для Layout который по идее должен располагаться на этом Activity и вызываем ChangeScene для нее. 
С обратным Transition все немного сложнее. При вызове onBackPressed опять создаем FrameLayout на основе пришедших данных, затем находим все элементы из этих данных на текущем экране, берем важные для данного типа view данные (к примеру для ImageView это drawable) и вставляем в наши элементы на FrameLayout. На основе этого FrameLayout формируем сцену и вызываем changeScene.
   
Еще нужно добавить какой-либо listener по завершению Transition, потому что сейчас завершение Activity делается с помощью postDelayed c отсрочкой равной длительности анимации, это кривой подход и бывает Activity завершается раньше, чем закончилась анимация.