### PR TITLE
Prevent leaking the current context in an static ArrayMap.

### DIFF
--- a/library/src/main/java/com/transitionseverywhere/TransitionInflater.java
+++ b/library/src/main/java/com/transitionseverywhere/TransitionInflater.java
@@ -47,12 +47,6 @@ import java.lang.reflect.InvocationTargetException;
  */
 public class TransitionInflater {
 
-    // We only need one inflater for any given context. Also, this allows us to associate
-    // ids with unique instances per-Context, used to avoid re-inflating
-    // already-inflated resources into new/different instances
-    private static final ArrayMap<Context, TransitionInflater> sInflaterMap =
-            new ArrayMap<Context, TransitionInflater>();
-
     private static final Class<?>[] sConstructorSignature = new Class[] {
             Context.class, AttributeSet.class};
     private final static ArrayMap<String, Constructor> sConstructors =
@@ -60,8 +54,6 @@ public class TransitionInflater {
 
 
     private Context mContext;
-    // TODO: do we need id maps for transitions and transitionMgrs as well?
-    SparseArray<Scene> mScenes = new SparseArray<Scene>();
 
     private TransitionInflater(Context context) {
         mContext = context;
@@ -71,13 +63,7 @@ public class TransitionInflater {
      * Obtains the TransitionInflater from the given context.
      */
     public static TransitionInflater from(Context context) {
-        TransitionInflater inflater = sInflaterMap.get(context);
-        if (inflater != null) {
-            return inflater;
-        }
-        inflater = new TransitionInflater(context);
-        sInflaterMap.put(context, inflater);
-        return inflater;
+        return new TransitionInflater(context);
     }
 
     /**


### PR DESCRIPTION
The current implementation has a big problem as it leaks the Context used to create the TransitionInflater in an static ArrayMap. When used with an Activity context it could leak the entire activity.

This code is already removed from the TransitionInflater class from Android as you can see here:

https://android.googlesource.com/platform/frameworks/base/+/58ad12208afcf9fdce735dead8449c4db375344d%5E%21/#F0