### PR TITLE
Fix bug where Recolor could change unrelated backgrounds

### DIFF
--- a/library/src/main/java/com/transitionseverywhere/Recolor.java
+++ b/library/src/main/java/com/transitionseverywhere/Recolor.java
@@ -128,6 +128,7 @@ public class Recolor extends Transition {
             ColorDrawable endColor = (ColorDrawable) endBackground;
             if (startColor.getColor() != endColor.getColor()) {
                 final int finalColor = endColor.getColor();
+                endColor = (ColorDrawable) endColor.mutate();
                 endColor.setColor(startColor.getColor());
                 bgAnimator = ObjectAnimator.ofInt(endColor, COLORDRAWABLE_COLOR, startColor.getColor(), finalColor);
                 bgAnimator.setEvaluator(new ArgbEvaluator());


### PR DESCRIPTION
ColorDrawable state may be shared between multiple backgrounds that happen to
have the same color. By calling mutate first before setting the color,
we make sure to only update the background color of the target view.